### PR TITLE
Adjust seek constants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -867,9 +867,9 @@ pub type UserData = u64;
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq, Prim)]
 pub enum Whence {
+    Start,
     Current,
     End,
-    Start,
 }
 
 impl From<Whence> for u8 {


### PR DESCRIPTION
The values of seek constants (Whence::Start, Whence::Current, Whence::End) defined in wasi types don't match the ones used by wasi-libc, resulting in a bug when the WASM programcalls `fd_seek()`.