### PR TITLE
Pinned version of bitflags to =1.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ std = []
 sgx = ["serde/mesalock_sgx", "sgx_tstd"]
 
 [dependencies]
-bitflags = "1.1"
+bitflags = "=1.2.1"
 proper = "0.1"
 serde = { git = "https://github.com/veracruz-project/serde.git", features=["derive"], branch = "veracruz" }
 err-derive = "0.2"


### PR DESCRIPTION
(Opened another PR after @ShaleXIONG mistakenly force-pushed to the `veracruz` branch).