### PR TITLE
Extend WASI rights with execute right

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -827,6 +827,7 @@ bitflags! {
         const PATH_UNLINK_FILE        = 1 << 26;
         const POLL_FD_READWRITE       = 1 << 27;
         const SOCK_SHUTDOWN           = 1 << 28;
+        const FD_EXECUTE              = 1 << 29;
     }
 }
 


### PR DESCRIPTION
Fix for https://github.com/veracruz-project/veracruz/issues/391.
Add execute right to WASI rights.
Works in combination with https://github.com/veracruz-project/veracruz/pull/420